### PR TITLE
fix: remove invalid twitter:card meta tag

### DIFF
--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -34,10 +34,6 @@ const Meta = () => (
 		<meta content="en_US" property="og:locale" />
 
 		{/* Twitter */}
-		<meta
-			content="Web developer and cybersecurity competitor."
-			name="twitter:card"
-		/>
 		<meta content="https://safin.dev" name="twitter:url" />
 		<meta content="Safin Singh" name="twitter:title" />
 		<meta


### PR DESCRIPTION
Hey Safin! I was poking around your codebase and it looks like you are using the `twitter:card` meta tag in your `Meta` component wrong. You can even see an error for this with [twitter's validator](https://cards-dev.twitter.com/validator).

Signed-off-by: Matt Gleich <git@mattglei.ch>